### PR TITLE
feat: add dynamic placeholder support for heading nodes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@radix-ui/react-slot": "^1.2.2",
         "@radix-ui/react-tooltip": "^1.2.6",
         "@tailwindcss/vite": "^4.1.7",
+        "@tiptap/extension-placeholder": "^2.12.0",
         "@tiptap/pm": "^2.12.0",
         "@tiptap/react": "^2.12.0",
         "@tiptap/starter-kit": "^2.12.0",
@@ -2220,6 +2221,19 @@
       },
       "peerDependencies": {
         "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-placeholder": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-2.12.0.tgz",
+      "integrity": "sha512-K7irDox4P+NLAMjVrJeG72f0sulsCRYpx1Cy4gxKCdi1LTivj5VkXa6MXmi42KTCwBu3pWajBctYIOAES1FTAA==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
       }
     },
     "node_modules/@tiptap/extension-strike": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@radix-ui/react-slot": "^1.2.2",
     "@radix-ui/react-tooltip": "^1.2.6",
     "@tailwindcss/vite": "^4.1.7",
+    "@tiptap/extension-placeholder": "^2.12.0",
     "@tiptap/pm": "^2.12.0",
     "@tiptap/react": "^2.12.0",
     "@tiptap/starter-kit": "^2.12.0",

--- a/src/editor-core/create-editor/DossierEditor.tsx
+++ b/src/editor-core/create-editor/DossierEditor.tsx
@@ -5,15 +5,17 @@ import { EditorContent } from '@tiptap/react';
 
 export const DossierEditor = () => {
   return (
-    <CoreEditor
-      className="dossier-editor"
-      getEnabledExtensions={getEnabledExtensions}
-      appearanceRenderer={({ editor }) => (
-        <>
-          <EditorContent editor={editor} />
-          <FloatingToolbar>This is me</FloatingToolbar>
-        </>
-      )}
-    />
+    <div className="dossier-editor-wrapper full-screen px-4 py-2">
+      <CoreEditor
+        className="dossier-editor full-screen"
+        getEnabledExtensions={getEnabledExtensions}
+        appearanceRenderer={({ editor }) => (
+          <>
+            <EditorContent editor={editor} />
+            <FloatingToolbar>This is me</FloatingToolbar>
+          </>
+        )}
+      />
+    </div>
   );
 };

--- a/src/editor-core/utils/get-enabled-extension.ts
+++ b/src/editor-core/utils/get-enabled-extension.ts
@@ -1,5 +1,38 @@
+import PlaceholderExtension from '@tiptap/extension-placeholder';
 import StarterKit from '@tiptap/starter-kit';
 
+export type NodeAttributes = { [key: string]: unknown };
+
+const NodeType = {
+  PARAGRAPH: 'paragraph',
+  HEADING: 'heading'
+};
+
+const PLACEHOLDERS = {
+  [NodeType.PARAGRAPH]: `Write press 'space' for AI, '/' for commands...`,
+  [NodeType.HEADING]: (attrs: NodeAttributes) => {
+    const { level } = attrs;
+    if (!level || typeof level !== 'number') return '';
+    return `Heading ${level.toString()}`;
+  }
+};
+
+const getPlaceholderForNodeType = ({ type, attrs }: { type: string; attrs: { [key: string]: any } }) => {
+  const pValue = PLACEHOLDERS[type];
+  if (typeof pValue === 'string') return pValue;
+  return pValue(attrs);
+};
+
 export function getEnabledExtensions() {
-  return [StarterKit];
+  return [
+    StarterKit,
+    PlaceholderExtension.configure({
+      emptyNodeClass: 'node-empty',
+      placeholder: ({ editor, node, hasAnchor }) => {
+        if (!editor.isEditable && !hasAnchor) return '';
+        const type = node.type.name;
+        return getPlaceholderForNodeType({ type, attrs: node.attrs });
+      }
+    })
+  ];
 }

--- a/src/index.css
+++ b/src/index.css
@@ -115,6 +115,14 @@
     box-sizing: border-box;
   }
 
+  html,
+  body,
+  #__dossier-root {
+    height: 100%;
+    margin: 0;
+    padding: 0;
+  }
+
   body {
     @apply bg-background text-foreground font-medium leading-6;
     font-family: Manrope, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
@@ -125,22 +133,46 @@
   }
 }
 
+.ProseMirror.dossier-editor {
+  display: flex;
+  flex-direction: column;
+  outline: none;
+  gap: 1rem;
+}
+
 .ProseMirror.dossier-editor h1 {
-  @apply scroll-m-20 text-4xl font-extrabold tracking-tight text-5xl leading-18;
+  @apply scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl lg:leading-16 mb-2;
 }
 
 .ProseMirror.dossier-editor h2 {
-  @apply scroll-m-20 text-3xl font-bold tracking-tight leading-10;
+  @apply scroll-m-20 text-3xl font-bold tracking-tight leading-10 mb-2;
 }
 
 .ProseMirror.dossier-editor h3 {
-  @apply scroll-m-20 text-2xl font-bold tracking-tight leading-10;
+  @apply scroll-m-20 text-2xl font-bold tracking-tight leading-8;
 }
 
 .ProseMirror.dossier-editor h4 {
-  @apply scroll-m-20 text-xl font-bold tracking-tight leading-8;
+  @apply scroll-m-20 text-xl font-bold tracking-tight leading-7;
 }
 
 .ProseMirror.dossier-editor p {
-  @apply leading-6 font-medium;
+  @apply leading-5 font-medium;
+  padding: 0 4px;
+}
+
+.full-screen {
+  @apply w-full h-full;
+}
+
+.dossier-editor-wrapper > div:first-child {
+  @apply w-full h-full;
+}
+
+.dossier-editor .node-empty::before {
+  @apply text-muted-foreground;
+  content: attr(data-placeholder);
+  float: left;
+  height: 0;
+  pointer-events: none;
 }


### PR DESCRIPTION
✅ **Summary**
This PR introduces a new feature to the editor by enhancing the placeholder behavior. Specifically, it:
- Adds a placeholder extension.
- Applies placeholder text for paragraph and heading nodes.

🧩 **Features**
- ✅ Placeholder support for:
- <p> (paragraphs)
- <h1>–<h6> (headings)

✨ Allows configuration of placeholder text.

🎯 Only applies placeholder when the node is empty and selected.